### PR TITLE
Fix typo in vitrine entry causing a runtime error

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -238,7 +238,8 @@ AddEventHandler('qb-jewelery:client:cabinetHandler', function()
     TriggerServerEvent('qb-jewelery:server:endcabinet')
 end)
 
-RegisterNetEvent('qb-jewelery:client:synceffects', function(closestVitrine, originalPlayer)
+RegisterNetEvent('qb-jewelery:client:synceffects', function(closestVitrines, originalPlayer)
+    closestVitrine = closestVitrines
     Wait(1500)
     if sharedConfig.vitrines[closestVitrine].rayFire == 'DES_Jewel_Cab4' then
         Wait(150)

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -16,7 +16,7 @@ return {
         [4] = {coords = vec3(-628.0, -233.86, 38.05), isOpened = false, isBusy = false, rayFire = 'DES_Jewel_Cab', heading = 216.17},
         [5] = {coords = vec3(-625.7, -237.8, 38.05), isOpened = false, isBusy = false, rayFire = 'DES_Jewel_Cab3', heading = 216.17},
         [6] = {coords = vec3(-626.7, -238.58, 38.05), isOpened = false, isBusy = false,  rayFire = 'DES_Jewel_Cab2', heading = 216.17},
-        [7] = {oords = vec3(-624.55, -231.06, 38.05), isOpened = false, isBusy = false, rayFire = 'DES_Jewel_Cab4', heading = 305.0},
+        [7] = {coords = vec3(-624.55, -231.06, 38.05), isOpened = false, isBusy = false, rayFire = 'DES_Jewel_Cab4', heading = 305.0},
         [8] = {coords = vec3(-623.13, -232.94, 38.05), isOpened = false, isBusy = false, rayFire = 'DES_Jewel_Cab', heading = 305.0},
         [9] = {coords = vec3(-620.29, -234.44, 38.05), isOpened = false, isBusy = false, rayFire = 'DES_Jewel_Cab', heading = 216.17},
         [10] = {coords = vec3(-619.15, -233.66, 38.05), isOpened = false, isBusy = false,  rayFire = 'DES_Jewel_Cab3', heading = 216.17},


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
In the `vitrines` array, there was a typo in the seventh entry where "oords" was used instead of "coords". This misspelling caused a runtime error when checking the distance between the player coordinates and the vitrine coordinates. This commit corrects the typo to ensure proper functionality.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ x ] My pull request fits the contribution guidelines & code conventions.

![Screenshot 2023-12-20 062628](https://github.com/Qbox-project/qbx_jewelery/assets/64894726/a055b404-9287-46c3-bbb6-6663952c3e2c)
