### PR TITLE
Fix for overweight item carry on rewards and optional custom drop creation

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -2,6 +2,7 @@ return {
     timeOut = 2700000,
     minimumPolice = 0,
     notEnoughPoliceNotify = true,
+    CreateCustomDrop = true,
     reward = {
         minAmount = 1,
         maxAmount = 2,

--- a/config/server.lua
+++ b/config/server.lua
@@ -2,7 +2,6 @@ return {
     timeOut = 2700000,
     minimumPolice = 0,
     notEnoughPoliceNotify = true,
-    CreateCustomDrop = true,
     reward = {
         minAmount = 1,
         maxAmount = 2,

--- a/locales/en.json
+++ b/locales/en.json
@@ -10,6 +10,7 @@
         "noweapon": "You don't have a weapon in hand",
         "noitem": "You don't have an %s with you",
         "police": "Vangelico Store robbery reported",
-        "nopolice": "Not Enough Police (%s Required)"
+        "nopolice": "Not Enough Police (%s Required)",
+        "reward_dropped": "You dropped some jewels"
     }
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -109,9 +109,23 @@ RegisterNetEvent('qbx_jewelery:server:endcabinet', function()
     sharedConfig.vitrines[closestVitrine].isBusy = false
     startedVitrine[source] = nil
 
+    local customDropItems = {}
     for _ = 1, math.random(config.reward.minAmount, config.reward.maxAmount) do
         local RandomItem = config.reward.items[math.random(1, #config.reward.items)]
-        player.Functions.AddItem(RandomItem.name, math.random(RandomItem.min, RandomItem.max))
+        local quantity = math.random(RandomItem.min, RandomItem.max)
+
+        if exports.ox_inventory:CanCarryItem(source, RandomItem.name, quantity) then
+            exports.ox_inventory:AddItem(source, RandomItem.name, quantity)
+        else
+            if config.CreateCustomDrop then
+                customDropItems[#customDropItems+1] = {RandomItem.name, quantity}
+            end
+        end
+    end
+
+    if config.CreateCustomDrop then
+        exports.ox_inventory:CustomDrop('jewelery', customDropItems, playerCoords)
+        exports.qbx_core:Notify(source, locale('notify.reward_dropped', 'x'..quantity..' '..ITEMS[RandomItem.name].label), 'warning')
     end
 
     TriggerClientEvent('qbx_jewelery:client:syncconfig', -1, sharedConfig.vitrines)

--- a/server/main.lua
+++ b/server/main.lua
@@ -96,7 +96,6 @@ local function fireAlarm()
 end
 
 RegisterNetEvent('qbx_jewelery:server:endcabinet', function()
-    local player = exports.qbx_core:GetPlayer(source)
     local playerCoords = GetEntityCoords(GetPlayerPed(source))
     local closestVitrine = startedVitrine[source]
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -117,13 +117,11 @@ RegisterNetEvent('qbx_jewelery:server:endcabinet', function()
         if exports.ox_inventory:CanCarryItem(source, RandomItem.name, quantity) then
             exports.ox_inventory:AddItem(source, RandomItem.name, quantity)
         else
-            if config.CreateCustomDrop then
-                customDropItems[#customDropItems+1] = {RandomItem.name, quantity}
-            end
+            customDropItems[#customDropItems+1] = {RandomItem.name, quantity}
         end
     end
 
-    if config.CreateCustomDrop and #customDropItems > 0 then
+    if #customDropItems > 0 then
         exports.ox_inventory:CustomDrop('jewelery', customDropItems, playerCoords)
         exports.qbx_core:Notify(source, locale('notify.reward_dropped'), 'warning')
     end

--- a/server/main.lua
+++ b/server/main.lua
@@ -125,7 +125,7 @@ RegisterNetEvent('qbx_jewelery:server:endcabinet', function()
 
     if config.CreateCustomDrop then
         exports.ox_inventory:CustomDrop('jewelery', customDropItems, playerCoords)
-        exports.qbx_core:Notify(source, locale('notify.reward_dropped', 'x'..quantity..' '..ITEMS[RandomItem.name].label), 'warning')
+        exports.qbx_core:Notify(source, locale('notify.reward_dropped'), 'warning')
     end
 
     TriggerClientEvent('qbx_jewelery:client:syncconfig', -1, sharedConfig.vitrines)

--- a/server/main.lua
+++ b/server/main.lua
@@ -123,7 +123,7 @@ RegisterNetEvent('qbx_jewelery:server:endcabinet', function()
         end
     end
 
-    if config.CreateCustomDrop then
+    if config.CreateCustomDrop and #customDropItems > 0 then
         exports.ox_inventory:CustomDrop('jewelery', customDropItems, playerCoords)
         exports.qbx_core:Notify(source, locale('notify.reward_dropped'), 'warning')
     end


### PR DESCRIPTION
## Description

This fix a problem that when players receive their reward they can carry more than they can actually support since it does not check the capacity limit of their inventory.

Optionally, the server owner is given the option to create a custom drop with the items that player cannot carry so  another player can collect them.

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
