### PR TITLE
fix(server): use correct event handler for player load

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -148,6 +148,6 @@ RegisterNetEvent('qbx_jewelery:server:succeshackdoor', function()
     TriggerEvent('ox_doorlock:setState', doorEntrance.id, 0)
 end)
 
-AddEventHandler('playerJoining', function(source)
+RegisterNetEvent('QBCore:Server:OnPlayerLoaded', function()
     TriggerClientEvent('qbx_jewelery:client:syncconfig', source, sharedConfig.vitrines)
 end)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Recent fxServer artifacts now throw a warning when triggering an event on a players network id vice server id. This moves the event to send the shared config status once the player has loaded in. This should additionally prevent desync issues if a player logs out as this doesn't trigger the `playerJoining` event for each character change

```
[script:qbx_jewelery:] Warning: [natives] TRIGGER_CLIENT_EVENT_INTERNAL: client 1 is not the same as the target 65536. This happens when the oldId from the playerJoining event is used. Use source instead.
```

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
