### PR TITLE
fix: bind jewelry rewards to timed robbery sessions

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -3,17 +3,50 @@ local sharedConfig = require 'config.shared'
 local electricalBusy
 local startedElectrical = {}
 local startedVitrine = {}
+local vitrineOwners = {}
 local alarmFired
 local ITEMS = exports.ox_inventory:Items()
+local ELECTRICAL_MIN_DURATION = 5000
+local ELECTRICAL_TIMEOUT = 90000
+local VITRINE_MIN_DURATION = 2500
+local VITRINE_TIMEOUT = 15000
+
+---@param startedAt number
+---@param timeout number
+---@return boolean
+local function isExpired(startedAt, timeout)
+    return GetGameTimer() - startedAt > timeout
+end
+
+---@param source number
+local function releaseVitrine(source)
+    local session = startedVitrine[source]
+    if not session then return end
+
+    local vitrine = sharedConfig.vitrines[session.index]
+    if vitrine then
+        vitrine.isBusy = false
+    end
+    vitrineOwners[session.index] = nil
+    startedVitrine[source] = nil
+end
 
 lib.callback.register('qbx_jewelery:callback:electricalbox', function(source)
     local player = exports.qbx_core:GetPlayer(source)
+    if not player then return end
+
     local playerCoords = GetEntityCoords(GetPlayerPed(source))
     local amount = exports.qbx_core:GetDutyCountType('leo')
 
     if electricalBusy then
-        exports.qbx_core:Notify(source, locale('notify.busy'))
-        return
+        local session = startedElectrical[electricalBusy]
+        if session and not isExpired(session.startedAt, ELECTRICAL_TIMEOUT) then
+            exports.qbx_core:Notify(source, locale('notify.busy'))
+            return
+        end
+
+        startedElectrical[electricalBusy] = nil
+        electricalBusy = nil
     end
 
     if exports.ox_inventory:Search(source, 'count', sharedConfig.doorlock.requiredItem) == 0 then
@@ -29,43 +62,70 @@ lib.callback.register('qbx_jewelery:callback:electricalbox', function(source)
 
     if #(playerCoords - vector3(sharedConfig.electrical.x, sharedConfig.electrical.y, sharedConfig.electrical.z)) > 2 then return end
 
-    electricalBusy = true
-    startedElectrical[source] = true
+    electricalBusy = source
+    startedElectrical[source] = { startedAt = GetGameTimer() }
 
     if sharedConfig.doorlock.loseItemOnUse then
-        player.Functions.RemoveItem(sharedConfig.doorlock.requiredItem, 1)
+        if not player.Functions.RemoveItem(sharedConfig.doorlock.requiredItem, 1) then
+            electricalBusy = nil
+            startedElectrical[source] = nil
+            return
+        end
     end
 
     return true
 end)
 
 lib.callback.register('qbx_jewelery:callback:cabinet', function(source, closestVitrine)
+    if type(closestVitrine) ~= 'number' or closestVitrine % 1 ~= 0 then return end
+
+    local vitrine = sharedConfig.vitrines[closestVitrine]
+    if not vitrine then return end
+
     local playerPed = GetPlayerPed(source)
+    if playerPed <= 0 then return end
+
     local playerCoords = GetEntityCoords(playerPed)
     local allPlayers = exports.qbx_core:GetQBPlayers()
 
-    if #(playerCoords - sharedConfig.vitrines[closestVitrine].coords) > 1.8 then return end
+    if #(playerCoords - vitrine.coords) > 1.8 then return end
 
     if not config.allowedWeapons[GetSelectedPedWeapon(playerPed)] then
         exports.qbx_core:Notify(source, locale('notify.noweapon'))
         return
     end
 
-    if sharedConfig.vitrines[closestVitrine].isBusy then
-        exports.qbx_core:Notify(source, locale('notify.busy'))
-        return
+    if vitrine.isBusy then
+        local owner = vitrineOwners[closestVitrine]
+        local session = owner and startedVitrine[owner]
+        if session and not isExpired(session.startedAt, VITRINE_TIMEOUT) then
+            exports.qbx_core:Notify(source, locale('notify.busy'))
+            return
+        end
+
+        if owner then
+            releaseVitrine(owner)
+        else
+            vitrine.isBusy = false
+        end
     end
 
-    if sharedConfig.vitrines[closestVitrine].isOpened then
+    if vitrine.isOpened then
         exports.qbx_core:Notify(source, locale('notify.cabinetdone'))
         return
     end
 
-    startedVitrine[source] = closestVitrine
-    sharedConfig.vitrines[closestVitrine].isBusy = true
+    if startedVitrine[source] then return end
+
+    startedVitrine[source] = {
+        index = closestVitrine,
+        startedAt = GetGameTimer(),
+    }
+    vitrineOwners[closestVitrine] = source
+    vitrine.isBusy = true
     for k in pairs(allPlayers) do
         if k ~= source then
-            if #(GetEntityCoords(GetPlayerPed(k)) - sharedConfig.vitrines[closestVitrine].coords) < 20 then
+            if #(GetEntityCoords(GetPlayerPed(k)) - vitrine.coords) < 20 then
                 TriggerClientEvent('qbx_jewelery:client:synceffects', k, closestVitrine, source)
             end
         end
@@ -73,7 +133,8 @@ lib.callback.register('qbx_jewelery:callback:cabinet', function(source, closestV
     return true
 end)
 
-local function fireAlarm()
+---@param source number
+local function fireAlarm(source)
     if alarmFired then return end
 
     TriggerEvent('police:server:policeAlert', locale('notify.police'), 1, source)
@@ -89,6 +150,11 @@ local function fireAlarm()
 
         for i = 1, #sharedConfig.vitrines do
             sharedConfig.vitrines[i].isOpened = false
+            sharedConfig.vitrines[i].isBusy = false
+            vitrineOwners[i] = nil
+        end
+        for playerId in pairs(startedVitrine) do
+            startedVitrine[playerId] = nil
         end
 
         TriggerClientEvent('qbx_jewelery:client:syncconfig', -1, sharedConfig.vitrines)
@@ -97,16 +163,25 @@ end
 
 RegisterNetEvent('qbx_jewelery:server:endcabinet', function()
     local playerCoords = GetEntityCoords(GetPlayerPed(source))
-    local closestVitrine = startedVitrine[source]
+    local session = startedVitrine[source]
+    if not session then return end
 
-    if not closestVitrine then return end
-    if sharedConfig.vitrines[closestVitrine].isOpened then return end
-    if not sharedConfig.vitrines[closestVitrine].isBusy then return end
-    if #(playerCoords - sharedConfig.vitrines[closestVitrine].coords) > 1.8 then return end
+    local closestVitrine = session.index
+    local vitrine = sharedConfig.vitrines[closestVitrine]
+    local elapsed = GetGameTimer() - session.startedAt
+    if not vitrine or vitrineOwners[closestVitrine] ~= source then return end
+    if elapsed < VITRINE_MIN_DURATION or elapsed > VITRINE_TIMEOUT then
+        releaseVitrine(source)
+        return
+    end
+    if vitrine.isOpened or not vitrine.isBusy then return end
+    if #(playerCoords - vitrine.coords) > 1.8 then
+        releaseVitrine(source)
+        return
+    end
 
-    sharedConfig.vitrines[closestVitrine].isOpened = true
-    sharedConfig.vitrines[closestVitrine].isBusy = false
-    startedVitrine[source] = nil
+    vitrine.isOpened = true
+    releaseVitrine(source)
 
     local customDropItems = {}
     for _ = 1, math.random(config.reward.minAmount, config.reward.maxAmount) do
@@ -126,26 +201,40 @@ RegisterNetEvent('qbx_jewelery:server:endcabinet', function()
     end
 
     TriggerClientEvent('qbx_jewelery:client:syncconfig', -1, sharedConfig.vitrines)
-    fireAlarm()
+    fireAlarm(source)
 end)
 
 RegisterNetEvent('qbx_jewelery:server:failedhackdoor', function()
-    electricalBusy = false
-    startedElectrical[source] = false
+    if electricalBusy ~= source or not startedElectrical[source] then return end
+
+    electricalBusy = nil
+    startedElectrical[source] = nil
 end)
 
 RegisterNetEvent('qbx_jewelery:server:succeshackdoor', function()
+    local session = startedElectrical[source]
+    if electricalBusy ~= source or not session then return end
+
     local doorEntrance = exports.ox_doorlock:getDoorFromName(sharedConfig.doorlock.name)
     local playerCoords = GetEntityCoords(GetPlayerPed(source))
+    local elapsed = GetGameTimer() - session.startedAt
 
-    if not electricalBusy then return end
-    if not startedElectrical[source] then return end
+    if elapsed < ELECTRICAL_MIN_DURATION or elapsed > ELECTRICAL_TIMEOUT then return end
     if #(playerCoords - vector3(sharedConfig.electrical.x, sharedConfig.electrical.y, sharedConfig.electrical.z)) > 2 then return end
+    if not doorEntrance then return end
 
-    electricalBusy = false
-    startedElectrical[source] = false
+    electricalBusy = nil
+    startedElectrical[source] = nil
     exports.qbx_core:Notify(source, 'Hack successful')
     TriggerEvent('ox_doorlock:setState', doorEntrance.id, 0)
+end)
+
+AddEventHandler('playerDropped', function()
+    if electricalBusy == source then
+        electricalBusy = nil
+        startedElectrical[source] = nil
+    end
+    releaseVitrine(source)
 end)
 
 RegisterNetEvent('QBCore:Server:OnPlayerLoaded', function()


### PR DESCRIPTION
## What changed
- bind electrical and vitrine completion events to the player that started them
- validate vitrine indexes before table access
- require plausible completion timing and expire stale sessions
- release reservations on failure, disconnect, and robbery reset
- verify item removal and door lookup before progressing

## Why
Client completion events were authorized by reusable booleans without ownership expiry or minimum duration. Other clients could cancel the active hack, stale reservations could block the robbery, and a compromised client could complete cabinet rewards immediately after starting.

## Validation
- git diff --check
- direct Lua state-transition, timing, and disconnect-path review